### PR TITLE
Fix service reloading

### DIFF
--- a/manifests/vpn.pp
+++ b/manifests/vpn.pp
@@ -312,7 +312,7 @@ Mode = switch
   }
 
   exec { $reload:
-    command	=> "service tinc-underlay reload",
+    command	=> "service $service reload",
     provider	=> 'shell',
     refreshonly	=> true,
   }


### PR DESCRIPTION
The reload shell command always tried to reload a mesh named "underlay". This commit let's actually reload the intended mesh.
(Whether reloading via a shell command is necessary at all is out of the scope of this pull request)