### PR TITLE
Fix indentation in generated config files

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -19,12 +19,12 @@ define l2mesh::host(
     before  => Service[$service],
     tag     => $tag,
     content => "Address = ${ip}
-    Port = ${port}
-    Compression = 0
-    TCPOnly = ${tcp_only}
+Port = ${port}
+Compression = 0
+TCPOnly = ${tcp_only}
 
-    ${public_key}
-    ",
+${public_key}
+",
 
   }
   concat::fragment { "${tag_conf}_${fqdn}":

--- a/manifests/vpn.pp
+++ b/manifests/vpn.pp
@@ -279,11 +279,11 @@ define l2mesh::vpn (
   concat::fragment { "${conf}_head":
     target  => $conf,
     content => "Name = ${fqdn}
-    AddressFamily = ipv4
-    Device = /dev/net/tun
-    Mode = switch
+AddressFamily = ipv4
+Device = /dev/net/tun
+Mode = switch
 
-    ",
+",
   }
 
 


### PR DESCRIPTION
The recent TAB cleanup introduced leading spaces in the generated tinc config files, which not only look strange, but cause the vpn to break and cause parses error in the whitespace-only line before the public
key block: 

> No value for variable `' on line 6 while reading config file


This change removes all indentation from the generated config files.

It would be nicer to use [heredocs](https://docs.puppet.com/puppet/latest/lang_data_string.html#heredocs), but they require to use the future parser in puppet 3, I'm not sure if this is acceptable to you.