### PR TITLE
Add "Provides" header to init script

### DIFF
--- a/templates/initscript.erb
+++ b/templates/initscript.erb
@@ -1,6 +1,6 @@
 #!/bin/sh
 ### BEGIN INIT INFO
-# Provides:
+# Provides:          <%= @service %>
 # Required-Start:    $remote_fs $syslog
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5


### PR DESCRIPTION
On Ubuntu, apt complains about the LSB comment missing a valid value for "Provides":
```
insserv: Script tinc-netname is broken: incomplete LSB comment.
insserv: missing valid name for `Provides:' please add.
```

This change let's the init script provide the service "tinc-netname" (netname being the name of the vpn).