### PR TITLE
Make ip address/port optional

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -1,11 +1,11 @@
 # vim: set expandtab:
 define l2mesh::host(
   $host,
-  $ip,
-  $port,
   $tcp_only,
   $public_key,
   $tag_conf,
+  $ip = undef,
+  $port = undef,
   $fqdn = $name,
   $conf = undef,
 ) {
@@ -21,9 +21,11 @@ define l2mesh::host(
     content => template('l2mesh/host.erb'),
 
   }
-  concat::fragment { "${tag_conf}_${fqdn}":
-    target  => $conf,
-    tag     => "${tag_conf}_${fqdn}",
-    content => "ConnectTO = ${fqdn}\n",
+  if $ip {
+    concat::fragment { "${tag_conf}_${fqdn}":
+      target  => $conf,
+      tag     => "${tag_conf}_${fqdn}",
+      content => "ConnectTO = ${fqdn}\n",
+    }
   }
 }

--- a/manifests/vpn.pp
+++ b/manifests/vpn.pp
@@ -154,10 +154,6 @@
 #
 # * Format and publish this documentation
 #
-# * What if a node is not reachable from the internet ? All other nodes
-#   will have a ConnectTO trying to reach it and this is a waste of
-#   resources although it does not break the mesh.
-#
 # * Add a test that checks if instantiating two lmesh does not run into
 #   a conflict ( l2mehs(ip = 1) + l2mesh(ip = 2) ). How is it done with
 #   rspec puppet ?
@@ -179,8 +175,8 @@
 # Copyright 2012 eNovance <licensing@enovance.com>
 #
 define l2mesh::vpn (
-  $ip,
-  $port,
+  $ip = undef,
+  $port = undef,
   $tcp_only = 'no',
 ) {
 

--- a/templates/host.erb
+++ b/templates/host.erb
@@ -1,5 +1,9 @@
+<% unless @ip.nil? -%>
 Address = <%= @ip %>
+<% unless @port.nil? -%>
 Port = <%= @port %>
+<% end -%>
+<% end -%>
 Compression = 0
 TCPOnly = <%= @tcp_only %>
 


### PR DESCRIPTION
Some participants of l2mesh networks are not publicly reachable from the
internet. Those hosts should not lead to a ConnectTO entry in the other
hosts' configurations.
This change adds support for this scenario by simply not specifying an
IP address for those hosts.

Additionally, it makes the port setting optional, which causes tinc to
default to the standard 655 port.